### PR TITLE
Add Dependabot config for daily GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
### Motivation
- Enable automated dependency update PRs for GitHub Actions by adding a Dependabot configuration that runs daily at a consistent local time.

### Description
- Add `.github/dependabot.yml` configuring `package-ecosystem: "github-actions"` at `directory: "/"` with a `schedule` of `interval: "daily"`, `time: "06:00"`, and `timezone: "Asia/Tokyo"`.

### Testing
- Verified the new file with `cat .github/dependabot.yml` and `nl -ba .github/dependabot.yml`, and confirmed the change was committed (`git status --short` showed no uncommitted changes and the commit was created) with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efea04ea588320ad94a6e806a4f0b9)