### PR TITLE
Add cfn-lint based RDS EngineVersion update checker workflow

### DIFF
--- a/.github/script/check_rds_engine_version.py
+++ b/.github/script/check_rds_engine_version.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Check CloudFormation RDS EngineVersion against cfn-lint internal schema data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+from dataclasses import dataclass
+
+import cfnlint
+from cfnlint.decode import decode
+
+
+_NUMERIC_VERSION_PATTERN = re.compile(r"^\d+(?:\.\d+){1,3}$")
+
+
+@dataclass
+class CheckResult:
+    logical_id: str
+    engine: str
+    current_version: str
+    latest_version: str
+    has_update: bool
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check whether RDS EngineVersion is outdated based on cfn-lint data"
+    )
+    parser.add_argument("--template", default="cloudformation.yml", help="Path to CloudFormation template")
+    parser.add_argument("--logical-id", default="MySQLDB", help="Logical ID of AWS::RDS::DBInstance")
+    parser.add_argument("--issue-body", help="Path to write issue markdown body")
+    parser.add_argument("--json-output", help="Path to write JSON result")
+    return parser.parse_args()
+
+
+def _version_key(version: str) -> tuple[int, ...] | None:
+    if not _NUMERIC_VERSION_PATTERN.fullmatch(version):
+        return None
+    return tuple(int(part) for part in version.split("."))
+
+
+def _load_template_db_props(template_path: str, logical_id: str) -> tuple[str, str]:
+    template, matches = decode(template_path)
+    if matches:
+        raise ValueError(f"Template parse warnings/errors: {matches}")
+
+    resources = template.get("Resources", {})
+    target = resources.get(logical_id)
+    if not target:
+        raise ValueError(f"Resource '{logical_id}' was not found in {template_path}")
+
+    if target.get("Type") != "AWS::RDS::DBInstance":
+        raise ValueError(f"Resource '{logical_id}' is not AWS::RDS::DBInstance")
+
+    props = target.get("Properties", {})
+    engine = str(props.get("Engine", "")).strip()
+    version = str(props.get("EngineVersion", "")).strip()
+
+    if not engine or not version:
+        raise ValueError(
+            f"Resource '{logical_id}' must define both Engine and EngineVersion properties"
+        )
+
+    return engine, version
+
+
+def _load_supported_engine_versions(engine: str) -> list[str]:
+    schema_path = (
+        pathlib.Path(cfnlint.__file__).parent
+        / "data/schemas/extensions/aws_rds_dbinstance/engine_version.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    all_of_rules = schema.get("allOf", [])
+    for rule in all_of_rules:
+        engine_const = (
+            rule.get("if", {})
+            .get("properties", {})
+            .get("Engine", {})
+            .get("const")
+        )
+        if engine_const != engine:
+            continue
+
+        versions = (
+            rule.get("then", {})
+            .get("properties", {})
+            .get("EngineVersion", {})
+            .get("enum", [])
+        )
+        return [str(v) for v in versions]
+
+    raise ValueError(f"No engine versions found in cfn-lint schema for engine '{engine}'")
+
+
+def _select_latest_numeric_version(versions: list[str]) -> str:
+    candidates: list[tuple[tuple[int, ...], str]] = []
+    for version in versions:
+        key = _version_key(version)
+        if key is not None:
+            candidates.append((key, version))
+
+    if not candidates:
+        raise ValueError("No numeric versions found in cfn-lint schema data")
+
+    candidates.sort(key=lambda item: item[0])
+    return candidates[-1][1]
+
+
+def _render_issue_body(result: CheckResult, template_path: str) -> str:
+    return "\n".join(
+        [
+            "## RDS EngineVersion update detected",
+            "",
+            f"- Resource Logical ID: `{result.logical_id}`",
+            f"- Engine: `{result.engine}`",
+            f"- Current EngineVersion in `{template_path}`: `{result.current_version}`",
+            f"- Latest EngineVersion from `cfn-lint` data: `{result.latest_version}`",
+            "",
+            "Please update the CloudFormation template if this upgrade is intended.",
+        ]
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+
+    engine, current_version = _load_template_db_props(args.template, args.logical_id)
+    supported_versions = _load_supported_engine_versions(engine)
+    latest_version = _select_latest_numeric_version(supported_versions)
+
+    has_update = _version_key(current_version) is not None and _version_key(latest_version) is not None and _version_key(current_version) < _version_key(latest_version)
+
+    result = CheckResult(
+        logical_id=args.logical_id,
+        engine=engine,
+        current_version=current_version,
+        latest_version=latest_version,
+        has_update=has_update,
+    )
+
+    result_json = {
+        "logical_id": result.logical_id,
+        "engine": result.engine,
+        "current_version": result.current_version,
+        "latest_version": result.latest_version,
+        "has_update": result.has_update,
+    }
+
+    print(json.dumps(result_json, ensure_ascii=False))
+
+    if args.json_output:
+        pathlib.Path(args.json_output).write_text(
+            json.dumps(result_json, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.issue_body:
+        pathlib.Path(args.issue_body).write_text(
+            _render_issue_body(result, args.template) + "\n", encoding="utf-8"
+        )
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with pathlib.Path(github_output).open("a", encoding="utf-8") as fp:
+            fp.write(f"has_update={'true' if result.has_update else 'false'}\n")
+            fp.write(f"engine={result.engine}\n")
+            fp.write(f"current_version={result.current_version}\n")
+            fp.write(f"latest_version={result.latest_version}\n")
+            fp.write(f"logical_id={result.logical_id}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cfn-rds-engine-update-check.yml
+++ b/.github/workflows/cfn-rds-engine-update-check.yml
@@ -1,0 +1,91 @@
+name: cfn rds engine update check
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - 'cloudformation.yml'
+      - '.github/script/check_rds_engine_version.py'
+      - '.github/workflows/cfn-rds-engine-update-check.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-rds-engine-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install cfn-lint
+        run: pip install cfn-lint
+
+      - name: Check RDS engine version
+        id: check
+        run: |
+          python .github/script/check_rds_engine_version.py \
+            --template cloudformation.yml \
+            --logical-id MySQLDB \
+            --issue-body /tmp/cfn-rds-update-issue.md
+
+      - name: Create issue when update exists
+        if: steps.check.outputs.has_update == 'true'
+        uses: actions/github-script@v8
+        env:
+          ISSUE_BODY_FILE: /tmp/cfn-rds-update-issue.md
+          ISSUE_TITLE: 'chore: update RDS ${{ steps.check.outputs.engine }} EngineVersion to ${{ steps.check.outputs.latest_version }} (${{ steps.check.outputs.logical_id }})'
+          ISSUE_LABEL: cfn-rds-engine-update
+        with:
+          script: |
+            const fs = require('node:fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = process.env.ISSUE_TITLE;
+            const label = process.env.ISSUE_LABEL;
+            const body = fs.readFileSync(process.env.ISSUE_BODY_FILE, 'utf8');
+
+            const { data: labels } = await github.rest.issues.listLabelsOnRepo({ owner, repo, per_page: 100 });
+            const hasLabel = labels.some((item) => item.name === label);
+            if (!hasLabel) {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: '1D76DB',
+                description: 'CloudFormation RDS engine version update reminder'
+              });
+            }
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+
+            const duplicate = issues.find((issue) => issue.title === title);
+            if (duplicate) {
+              core.info(`Skip creating issue because it already exists: #${duplicate.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: [label],
+            });
+
+            core.info(`Created issue #${created.data.number}`);

--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ aws cloudformation deploy \
 
 This repository runs `cfn-lint` on pull requests using `shogo82148/actions-cfn-lint@v1` (reviewdog integrated) and reports results as a PR check.
 Workflow file: `.github/workflows/reviewdog-cfn-lint.yml`.
+
+
+## CI (RDS EngineVersion update check)
+
+This repository includes a scheduled workflow that:
+
+- installs `cfn-lint` with `pip`
+- reads `cfn-lint` internal schema data for `AWS::RDS::DBInstance` EngineVersion
+- compares it with the `MySQLDB` EngineVersion in `cloudformation.yml`
+- automatically creates a GitHub Issue when a newer version is detected
+
+Files:
+- Workflow: `.github/workflows/cfn-rds-engine-update-check.yml`
+- Script: `.github/script/check_rds_engine_version.py`
+


### PR DESCRIPTION
### Motivation

- Detect when an `AWS::RDS::DBInstance` `EngineVersion` in the repository's CloudFormation template is older than versions known to `cfn-lint`, and automate notification. 
- Provide a scheduled/manual CI job that installs `cfn-lint` via `pip`, reads its internal schema data, and files a GitHub Issue when a newer numeric engine version is available.

### Description

- Add `.github/script/check_rds_engine_version.py` which reads `cloudformation.yml`, extracts `Engine` and `EngineVersion` for a given logical ID, loads `cfn-lint` internal schema `data/schemas/extensions/aws_rds_dbinstance/engine_version.json`, selects the latest numeric version, emits JSON/issue body, and writes GitHub Actions outputs via `GITHUB_OUTPUT`.
- Add `.github/workflows/cfn-rds-engine-update-check.yml` which runs on a schedule/manual/when relevant files change, installs `cfn-lint` (`pip install cfn-lint`), runs the checker script, and uses `actions/github-script` to create or deduplicate an issue with a repository label when an update is detected.
- Update `README.md` to document the new CI workflow and the script location (`.github/script/check_rds_engine_version.py`).

### Testing

- Installed `cfn-lint` locally with `python -m pip install cfn-lint`, and the install completed successfully. 
- Executed the checker locally with `python .github/script/check_rds_engine_version.py --template cloudformation.yml --logical-id MySQLDB --json-output /tmp/check.json --issue-body /tmp/issue.md`, which produced JSON and issue markdown and detected an update (`8.0.35` -> `8.4.8`), indicating update retrieval works. 
- Verified the script compiles with `python -m py_compile .github/script/check_rds_engine_version.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a8f468788320b7e011c9f7c4e0f4)