### PR TITLE
Add GitHub Action and script to detect RDS EngineVersion updates using cfn-lint data

### DIFF
--- a/.github/script/check_rds_engine_updates.py
+++ b/.github/script/check_rds_engine_updates.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Check CloudFormation RDS EngineVersion values against cfn-lint internal engine data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import cfnlint
+from cfnlint.decode import cfn_yaml
+
+
+def natural_version_key(value: str) -> list[Any]:
+    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
+    key: list[Any] = []
+    for p in parts:
+        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
+    return key
+
+
+def cfn_lint_rds_engine_versions(engine: str) -> list[str]:
+    base = Path(cfnlint.__file__).resolve().parent
+    path = base / "data" / "schemas" / "extensions" / "aws_rds_dbinstance" / "engine_version.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    versions: set[str] = set()
+    for block in data.get("allOf", []):
+        when = block.get("if", {}).get("properties", {})
+        target = when.get("Engine", {}).get("const")
+        if target != engine:
+            continue
+
+        enum_values = (
+            block.get("then", {})
+            .get("properties", {})
+            .get("EngineVersion", {})
+            .get("enum", [])
+        )
+        versions.update(str(v) for v in enum_values)
+
+    return sorted(versions, key=natural_version_key)
+
+
+def extract_rds_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    resources = template.get("Resources", {})
+    results: list[dict[str, str]] = []
+    for logical_id, resource in resources.items():
+        if resource.get("Type") != "AWS::RDS::DBInstance":
+            continue
+
+        props = resource.get("Properties", {})
+        engine = props.get("Engine")
+        engine_version = props.get("EngineVersion")
+        if isinstance(engine, str) and isinstance(engine_version, str):
+            results.append(
+                {
+                    "logical_id": logical_id,
+                    "engine": engine,
+                    "current_version": engine_version,
+                }
+            )
+    return results
+
+
+def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
+    first = updates[0]
+    title = (
+        f"chore: RDS engine update available ({first['logical_id']} {first['current_version']} -> {first['latest_version']})"
+    )
+    lines = [
+        "CloudFormation の RDS エンジンバージョン更新候補が見つかりました。",
+        "",
+        f"Template: `{template_path}`",
+        "",
+        "| Logical ID | Engine | Current | Latest (cfn-lint data) |",
+        "|---|---|---|---|",
+    ]
+    for u in updates:
+        lines.append(
+            f"| `{u['logical_id']}` | `{u['engine']}` | `{u['current_version']}` | `{u['latest_version']}` |"
+        )
+    lines.append("")
+    lines.append("この Issue は `.github/script/check_rds_engine_updates.py` により自動生成されました。")
+    return title, "\n".join(lines)
+
+
+def write_github_output(path: str, outputs: dict[str, str]) -> None:
+    with open(path, "a", encoding="utf-8") as fp:
+        for key, value in outputs.items():
+            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template", default="cloudformation.yml")
+    parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+
+    template_path = Path(args.template)
+    template = cfn_yaml.load(str(template_path))
+    rds_resources = extract_rds_resources(template)
+
+    updates: list[dict[str, str]] = []
+    for r in rds_resources:
+        versions = cfn_lint_rds_engine_versions(r["engine"])
+        if not versions:
+            continue
+        latest = versions[-1]
+        if natural_version_key(r["current_version"]) < natural_version_key(latest):
+            updates.append({**r, "latest_version": latest})
+
+    has_update = bool(updates)
+    issue_title = ""
+    issue_body = ""
+    if has_update:
+        issue_title, issue_body = build_issue(updates, template_path)
+
+    result = {
+        "has_update": has_update,
+        "template": str(template_path),
+        "updates": updates,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if args.github_output:
+        write_github_output(
+            args.github_output,
+            {
+                "has_update": "true" if has_update else "false",
+                "issue_title": issue_title,
+                "issue_body": issue_body,
+            },
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -1,0 +1,66 @@
+name: Check RDS Engine Version Updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-rds-engine-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cfn-lint
+
+      - name: Check RDS engine updates from cfn-lint data
+        id: check
+        run: |
+          python .github/script/check_rds_engine_updates.py --template cloudformation.yml
+
+      - name: Create issue when update exists
+        if: steps.check.outputs.has_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `${{ steps.check.outputs.issue_title }}`;
+            const body = `${{ steps.check.outputs.issue_body }}`;
+
+            const { owner, repo } = context.repo;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              creator: 'github-actions[bot]',
+              per_page: 100,
+            });
+
+            const duplicate = existing.data.find((issue) => issue.title === title);
+            if (duplicate) {
+              core.info(`Issue already exists: #${duplicate.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['dependencies', 'rds'],
+            });
+
+            core.info(`Created issue #${created.data.number}`);


### PR DESCRIPTION
### Motivation
- Provide an automated check that detects newer RDS `EngineVersion` values in CloudFormation templates by reading `cfn-lint`'s internal engine data so repository owners can be notified to review dependency updates.
- Place the check implementation under repository-managed CI locations so it can run on schedule or via manual dispatch and create issues when updates are found.

### Description
- Add script ` .github/script/check_rds_engine_updates.py` that loads a CloudFormation template, extracts `AWS::RDS::DBInstance` `Engine`/`EngineVersion` entries, reads `cfn-lint`'s `data/schemas/extensions/aws_rds_dbinstance/engine_version.json`, and compares versions using a natural sort key.
- The script outputs structured JSON to stdout and writes GitHub Actions outputs (`has_update`, `issue_title`, `issue_body`) when `GITHUB_OUTPUT` is provided, and builds a markdown issue body summarizing detected updates.
- Add workflow `.github/workflows/check-rds-engine-version.yml` that installs `cfn-lint` via pip, runs the check script (`--template cloudformation.yml`), and creates an issue via `actions/github-script@v7` when an update is detected while avoiding duplicate issues.

### Testing
- Ran `python -m pip install --quiet cfn-lint` which completed successfully in the environment. (succeeded)
- Ran `python .github/script/check_rds_engine_updates.py --template cloudformation.yml` which printed JSON showing an update for `MySQLDB` from `8.0.35` to `8.4.8`, confirming the check detects available newer versions. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a8f468788320b7e011c9f7c4e0f4)