### PR TITLE
ci: bump check-rds-engine-version workflow to Python 3.13

### DIFF
--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Motivation
- Ensure the scheduled `check-rds-engine-version` workflow uses Python `3.13` by updating the `actions/setup-python` configuration.

### Description
- Updated `python-version` in `.github/workflows/check-rds-engine-version.yml` from `"3.12"` to `"3.13"`.

### Testing
- Verified the change with `git diff .github/workflows/check-rds-engine-version.yml`, inspected the updated lines, and committed the update, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ad377e748320b4098c8c883465be)