### PR TITLE
Adjust RDS engine version check schedule to 06:00 JST

### DIFF
--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -3,7 +3,8 @@ name: Check RDS Engine Version Updates
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *"
+    # 06:00 Asia/Tokyo (GitHub Actions schedule uses UTC)
+    - cron: "0 21 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- Run the RDS engine version check at 06:00 Asia/Tokyo daily by converting the requested local time to the UTC cron expression GitHub Actions requires.

### Description
- Update `.github/workflows/check-rds-engine-version.yml` to replace `- cron: "0 1 * * *"` with a comment `# 06:00 Asia/Tokyo (GitHub Actions schedule uses UTC)` and `- cron: "0 21 * * *"` to represent 06:00 JST in UTC.

### Testing
- Verified the change with `git diff` and confirmed repository status with `git status --short`, both reporting the expected update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0adbfe6308320837d2b1e715857a9)