### PR TITLE
Fix github-script syntax error when creating RDS update issue

### DIFF
--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -36,8 +36,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `${{ steps.check.outputs.issue_title }}`;
-            const body = `${{ steps.check.outputs.issue_body }}`;
+            const title = ${{ toJSON(steps.check.outputs.issue_title) }};
+            const body = ${{ toJSON(steps.check.outputs.issue_body) }};
 
             const { owner, repo } = context.repo;
 


### PR DESCRIPTION
### Motivation
- Prevent `SyntaxError: Unexpected identifier 'cloudformation'` when `actions/github-script` in the workflow receives multi-line or backtick-containing outputs for issue title/body.

### Description
- Replace JS template literals with `toJSON(...)` serialization for `steps.check.outputs.issue_title` and `steps.check.outputs.issue_body` in `.github/workflows/check-rds-engine-version.yml` so the `title` and `body` values are injected as safe JSON strings.

### Testing
- Ran `python -m py_compile .github/script/check_rds_engine_updates.py` which succeeded and inspected the workflow diff to confirm only the serialization handling changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ad1b18ac8320a80241575b97ffe6)