### PR TITLE
Add pull_request path trigger to RDS engine version check workflow

### DIFF
--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -2,6 +2,11 @@ name: Check RDS Engine Version Updates
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - cloudformation.yml
+      - .github/script/check_rds_engine_updates.py
+      - .github/workflows/check-rds-engine-version.yml
   schedule:
     # 06:00 Asia/Tokyo (GitHub Actions schedule uses UTC)
     - cron: "0 21 * * *"


### PR DESCRIPTION
### Motivation
- Ensure the RDS engine version check workflow runs for pull requests that modify the template or the check logic.
- Limit PR-triggered runs so the workflow only executes when relevant files are changed.

### Description
- Updated `.github/workflows/check-rds-engine-version.yml` to add a `pull_request` trigger.
- The `pull_request` trigger is restricted to the following paths: `cloudformation.yml`, `.github/script/check_rds_engine_updates.py`, and `.github/workflows/check-rds-engine-version.yml`.
- No other workflow steps or behavior were modified.

### Testing
- No automated CI/runtime tests were executed because this change only updates workflow trigger configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0afb890948320950ae257851a303b)