### PR TITLE
ci: bump check-rds-engine-version workflow Python to 3.14

### DIFF
--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Motivation
- Update the GitHub Actions Python runtime used by the RDS engine check workflow to Python `3.14` to align with the requested environment.

### Description
- Changed `python-version` in `.github/workflows/check-rds-engine-version.yml` from `3.13` to `3.14`.

### Testing
- No automated tests were run for this single-line YAML configuration update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b0b3fda483208c29861b1d572259)