### PR TITLE
Add ElastiCache engine-version update check workflow

### DIFF
--- a/.github/script/check_elasticache_engine_updates.py
+++ b/.github/script/check_elasticache_engine_updates.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Check CloudFormation ElastiCache EngineVersion values against cfn-lint internal engine data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import cfnlint
+from cfnlint.decode import cfn_yaml
+
+
+def natural_version_key(value: str) -> list[Any]:
+    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
+    key: list[Any] = []
+    for p in parts:
+        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
+    return key
+
+
+def cfn_lint_elasticache_engine_versions(engine: str) -> list[str]:
+    base = Path(cfnlint.__file__).resolve().parent
+    candidate_paths = [
+        base
+        / "data"
+        / "schemas"
+        / "extensions"
+        / "aws_elasticache_replicationgroup"
+        / "engine_version.json",
+        # ReplicationGroup updates can be tracked with the same ElastiCache engine dataset
+        # when a dedicated schema extension file is not available.
+        base
+        / "data"
+        / "schemas"
+        / "extensions"
+        / "aws_elasticache_cachecluster"
+        / "engine_version.json",
+    ]
+
+    data = {}
+    for path in candidate_paths:
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            break
+    if not data:
+        return []
+
+    versions: set[str] = set()
+    for block in data.get("allOf", []):
+        when = block.get("if", {}).get("properties", {})
+        target = when.get("Engine", {}).get("const")
+        if target != engine:
+            continue
+
+        enum_values = (
+            block.get("then", {})
+            .get("properties", {})
+            .get("EngineVersion", {})
+            .get("enum", [])
+        )
+        versions.update(str(v) for v in enum_values)
+
+    return sorted(versions, key=natural_version_key)
+
+
+def extract_elasticache_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    resources = template.get("Resources", {})
+    results: list[dict[str, str]] = []
+    for logical_id, resource in resources.items():
+        if resource.get("Type") != "AWS::ElastiCache::ReplicationGroup":
+            continue
+
+        props = resource.get("Properties", {})
+        engine = props.get("Engine")
+        engine_version = props.get("EngineVersion")
+        if isinstance(engine, str) and isinstance(engine_version, str):
+            results.append(
+                {
+                    "logical_id": logical_id,
+                    "engine": engine,
+                    "current_version": engine_version,
+                }
+            )
+    return results
+
+
+def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
+    first = updates[0]
+    title = (
+        "chore: ElastiCache engine update available "
+        f"({first['logical_id']} {first['current_version']} -> {first['latest_version']})"
+    )
+    lines = [
+        "CloudFormation の ElastiCache エンジンバージョン更新候補が見つかりました。",
+        "",
+        f"Template: `{template_path}`",
+        "",
+        "| Logical ID | Engine | Current | Latest (cfn-lint data) |",
+        "|---|---|---|---|",
+    ]
+    for u in updates:
+        lines.append(
+            f"| `{u['logical_id']}` | `{u['engine']}` | `{u['current_version']}` | `{u['latest_version']}` |"
+        )
+    lines.append("")
+    lines.append(
+        "この Issue は `.github/script/check_elasticache_engine_updates.py` により自動生成されました。"
+    )
+    return title, "\n".join(lines)
+
+
+def write_github_output(path: str, outputs: dict[str, str]) -> None:
+    with open(path, "a", encoding="utf-8") as fp:
+        for key, value in outputs.items():
+            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template", default="cloudformation.yml")
+    parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+
+    template_path = Path(args.template)
+    template = cfn_yaml.load(str(template_path))
+    elasticache_resources = extract_elasticache_resources(template)
+
+    updates: list[dict[str, str]] = []
+    for resource in elasticache_resources:
+        versions = cfn_lint_elasticache_engine_versions(resource["engine"])
+        if not versions:
+            continue
+        latest = versions[-1]
+        if natural_version_key(resource["current_version"]) < natural_version_key(latest):
+            updates.append({**resource, "latest_version": latest})
+
+    has_update = bool(updates)
+    issue_title = ""
+    issue_body = ""
+    if has_update:
+        issue_title, issue_body = build_issue(updates, template_path)
+
+    result = {
+        "has_update": has_update,
+        "template": str(template_path),
+        "updates": updates,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if args.github_output:
+        write_github_output(
+            args.github_output,
+            {
+                "has_update": "true" if has_update else "false",
+                "issue_title": issue_title,
+                "issue_body": issue_body,
+            },
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-elasticache-engine-version.yml
+++ b/.github/workflows/check-elasticache-engine-version.yml
@@ -1,0 +1,72 @@
+name: Check ElastiCache Engine Version Updates
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - cloudformation.yml
+      - .github/script/check_elasticache_engine_updates.py
+      - .github/workflows/check-elasticache-engine-version.yml
+  schedule:
+    # 06:00 Asia/Tokyo (GitHub Actions schedule uses UTC)
+    - cron: "0 21 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-elasticache-engine-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cfn-lint
+
+      - name: Check ElastiCache engine updates from cfn-lint data
+        id: check
+        run: |
+          python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml
+
+      - name: Create issue when update exists
+        if: steps.check.outputs.has_update == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = ${{ toJSON(steps.check.outputs.issue_title) }};
+            const body = ${{ toJSON(steps.check.outputs.issue_body) }};
+
+            const { owner, repo } = context.repo;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              creator: 'github-actions[bot]',
+              per_page: 100,
+            });
+
+            const duplicate = existing.data.find((issue) => issue.title === title);
+            if (duplicate) {
+              core.info(`Issue already exists: #${duplicate.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['dependencies', 'elasticache'],
+            });
+
+            core.info(`Created issue #${created.data.number}`);

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ aws cloudformation deploy \
 
 This repository runs `cfn-lint` on pull requests using `shogo82148/actions-cfn-lint@v1` (reviewdog integrated) and reports results as a PR check.
 Workflow file: `.github/workflows/reviewdog-cfn-lint.yml`.
+
+It also includes scheduled engine-version checks based on cfn-lint schema data:
+- RDS: `.github/workflows/check-rds-engine-version.yml`
+- ElastiCache: `.github/workflows/check-elasticache-engine-version.yml`


### PR DESCRIPTION
### Motivation

- Provide an automated, scheduled check for ElastiCache engine-version drift mirroring the existing RDS check to keep CloudFormation templates up to date.
- Detect `Engine`/`EngineVersion` values in `AWS::ElastiCache::ReplicationGroup` resources and compare them against cfn-lint shipped engine-version data.
- Support environments where cfn-lint lacks a ReplicationGroup-specific schema by falling back to the CacheCluster engine-version dataset.

### Description

- Added ` .github/script/check_elasticache_engine_updates.py` which extracts `AWS::ElastiCache::ReplicationGroup` resources, resolves available engine versions from cfn-lint data (with a fallback to `aws_elasticache_cachecluster/engine_version.json`), and builds issue title/body when updates are available.
- Added GitHub Actions workflow ` .github/workflows/check-elasticache-engine-version.yml` that runs on schedule, workflow dispatch, and on PRs touching the template or script, and creates a deduplicated issue labeled `dependencies` and `elasticache` when an update exists.
- Updated `README.md` to document the new scheduled engine-version checks for ElastiCache alongside the existing RDS check.

### Testing

- Ran `python -m py_compile .github/script/check_rds_engine_updates.py .github/script/check_elasticache_engine_updates.py` and the compilation succeeded.
- Executed `python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml` which completed and printed `"has_update": false` indicating no ElastiCache updates for the sample template.
- Executed `python .github/script/check_rds_engine_updates.py --template cloudformation.yml` which completed and printed `"has_update": true` with an RDS update detected (`MySQLDB` 8.0.35 -> 8.4.8).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b19e40188320828f2f6d6905dea2)