### PR TITLE
Update RDS MySQL EngineVersion to 8.4.7

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -118,7 +118,7 @@ Resources:
     Properties:
       DBInstanceIdentifier: !Sub '${AWS::StackName}-mysql'
       Engine: mysql
-      EngineVersion: '8.0.35'
+      EngineVersion: '8.4.7'
       DBName: !Ref DBName
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword


### PR DESCRIPTION
### Motivation
- Bump the RDS MySQL engine version in the CloudFormation template to `8.4.7` to align with the requested upgrade.

### Description
- Change the `MySQLDB` resource `EngineVersion` in `cloudformation.yml` from `'8.0.35'` to `'8.4.7'`.

### Testing
- Applied the automated text replacement (`python`), verified the result with `rg -n "EngineVersion" cloudformation.yml` and `nl -ba` to confirm `EngineVersion: '8.4.7'`, and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b3dfbc948320b6a8ce243a9b5c15)