### PR TITLE
Add Lambda runtime update check workflow

### DIFF
--- a/.github/script/check_lambda_runtime_updates.py
+++ b/.github/script/check_lambda_runtime_updates.py
@@ -73,11 +73,10 @@ def extract_lambda_resources(template: dict[str, Any]) -> list[dict[str, str]]:
     return results
 
 
-def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
-    first = updates[0]
+def build_issue(update: dict[str, str], template_path: Path) -> tuple[str, str]:
     title = (
         "chore: Lambda runtime update available "
-        f"({first['logical_id']} {first['current_runtime']} -> {first['latest_runtime']})"
+        f"({update['logical_id']} {update['current_runtime']} -> {update['latest_runtime']})"
     )
     lines = [
         "CloudFormation の Lambda ランタイム更新候補が見つかりました。",
@@ -86,15 +85,10 @@ def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str
         "",
         "| Logical ID | Current Runtime | Latest (cfn-lint schema) |",
         "|---|---|---|",
+        f"| `{update['logical_id']}` | `{update['current_runtime']}` | `{update['latest_runtime']}` |",
+        "",
+        "この Issue は `.github/script/check_lambda_runtime_updates.py` により自動生成されました。",
     ]
-    for u in updates:
-        lines.append(
-            f"| `{u['logical_id']}` | `{u['current_runtime']}` | `{u['latest_runtime']}` |"
-        )
-    lines.append("")
-    lines.append(
-        "この Issue は `.github/script/check_lambda_runtime_updates.py` により自動生成されました。"
-    )
     return title, "\n".join(lines)
 
 
@@ -122,16 +116,17 @@ def main() -> int:
         if latest and resource["current_runtime"] != latest:
             updates.append({**resource, "latest_runtime": latest})
 
-    has_update = bool(updates)
-    issue_title = ""
-    issue_body = ""
-    if has_update:
-        issue_title, issue_body = build_issue(updates, template_path)
+    issue_payloads: list[dict[str, str]] = []
+    for update in updates:
+        title, body = build_issue(update, template_path)
+        issue_payloads.append({"title": title, "body": body})
 
+    has_update = bool(issue_payloads)
     result = {
         "has_update": has_update,
         "template": str(template_path),
         "updates": updates,
+        "issues": issue_payloads,
     }
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
@@ -140,8 +135,7 @@ def main() -> int:
             args.github_output,
             {
                 "has_update": "true" if has_update else "false",
-                "issue_title": issue_title,
-                "issue_body": issue_body,
+                "issues": json.dumps(issue_payloads, ensure_ascii=False),
             },
         )
 

--- a/.github/script/check_lambda_runtime_updates.py
+++ b/.github/script/check_lambda_runtime_updates.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Check CloudFormation Lambda Runtime values against cfn-lint provider schema data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from cfnlint.decode import cfn_yaml
+from cfnlint.schema.manager import ProviderSchemaManager
+
+
+def natural_version_key(value: str) -> list[Any]:
+    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
+    key: list[Any] = []
+    for p in parts:
+        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
+    return key
+
+
+def runtime_family_and_version(runtime: str) -> tuple[str, str]:
+    if runtime.startswith("provided.al"):
+        return "provided.al", runtime.removeprefix("provided.al")
+
+    patterns = ["python", "nodejs", "java", "dotnetcore", "dotnet", "ruby"]
+    for prefix in patterns:
+        if runtime.startswith(prefix):
+            return prefix, runtime.removeprefix(prefix)
+
+    return runtime, ""
+
+
+def cfn_lint_lambda_runtimes(region: str = "us-east-1") -> list[str]:
+    manager = ProviderSchemaManager()
+    schema = manager.get_resource_schema(region, "AWS::Lambda::Function")
+    runtimes = schema.schema.get("properties", {}).get("Runtime", {}).get("enum", [])
+    return sorted((str(r) for r in runtimes), key=natural_version_key)
+
+
+def latest_runtime_for_family(current_runtime: str, runtimes: list[str]) -> str | None:
+    family, _ = runtime_family_and_version(current_runtime)
+
+    family_runtimes = [r for r in runtimes if runtime_family_and_version(r)[0] == family]
+    if not family_runtimes:
+        return None
+
+    return sorted(
+        family_runtimes,
+        key=lambda r: natural_version_key(runtime_family_and_version(r)[1]),
+    )[-1]
+
+
+def extract_lambda_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    resources = template.get("Resources", {})
+    results: list[dict[str, str]] = []
+    for logical_id, resource in resources.items():
+        if resource.get("Type") != "AWS::Lambda::Function":
+            continue
+
+        props = resource.get("Properties", {})
+        runtime = props.get("Runtime")
+        if isinstance(runtime, str):
+            results.append(
+                {
+                    "logical_id": logical_id,
+                    "current_runtime": runtime,
+                }
+            )
+    return results
+
+
+def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
+    first = updates[0]
+    title = (
+        "chore: Lambda runtime update available "
+        f"({first['logical_id']} {first['current_runtime']} -> {first['latest_runtime']})"
+    )
+    lines = [
+        "CloudFormation の Lambda ランタイム更新候補が見つかりました。",
+        "",
+        f"Template: `{template_path}`",
+        "",
+        "| Logical ID | Current Runtime | Latest (cfn-lint schema) |",
+        "|---|---|---|",
+    ]
+    for u in updates:
+        lines.append(
+            f"| `{u['logical_id']}` | `{u['current_runtime']}` | `{u['latest_runtime']}` |"
+        )
+    lines.append("")
+    lines.append(
+        "この Issue は `.github/script/check_lambda_runtime_updates.py` により自動生成されました。"
+    )
+    return title, "\n".join(lines)
+
+
+def write_github_output(path: str, outputs: dict[str, str]) -> None:
+    with open(path, "a", encoding="utf-8") as fp:
+        for key, value in outputs.items():
+            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template", default="cloudformation.yml")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+
+    template_path = Path(args.template)
+    template = cfn_yaml.load(str(template_path))
+    lambda_resources = extract_lambda_resources(template)
+    runtimes = cfn_lint_lambda_runtimes(args.region)
+
+    updates: list[dict[str, str]] = []
+    for resource in lambda_resources:
+        latest = latest_runtime_for_family(resource["current_runtime"], runtimes)
+        if latest and resource["current_runtime"] != latest:
+            updates.append({**resource, "latest_runtime": latest})
+
+    has_update = bool(updates)
+    issue_title = ""
+    issue_body = ""
+    if has_update:
+        issue_title, issue_body = build_issue(updates, template_path)
+
+    result = {
+        "has_update": has_update,
+        "template": str(template_path),
+        "updates": updates,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if args.github_output:
+        write_github_output(
+            args.github_output,
+            {
+                "has_update": "true" if has_update else "false",
+                "issue_title": issue_title,
+                "issue_body": issue_body,
+            },
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -37,14 +37,12 @@ jobs:
         run: |
           python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml
 
-      - name: Create issue when update exists
+      - name: Create issues when update exists
         if: steps.check.outputs.has_update == 'true'
         uses: actions/github-script@v9
         with:
           script: |
-            const title = ${{ toJSON(steps.check.outputs.issue_title) }};
-            const body = ${{ toJSON(steps.check.outputs.issue_body) }};
-
+            const issues = ${{ fromJSON(steps.check.outputs.issues) }};
             const { owner, repo } = context.repo;
 
             const existing = await github.rest.issues.listForRepo({
@@ -55,18 +53,21 @@ jobs:
               per_page: 100,
             });
 
-            const duplicate = existing.data.find((issue) => issue.title === title);
-            if (duplicate) {
-              core.info(`Issue already exists: #${duplicate.number}`);
-              return;
+            const openTitles = new Set(existing.data.map((issue) => issue.title));
+
+            for (const issue of issues) {
+              if (openTitles.has(issue.title)) {
+                core.info(`Issue already exists: ${issue.title}`);
+                continue;
+              }
+
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title: issue.title,
+                body: issue.body,
+                labels: ['dependencies', 'lambda'],
+              });
+
+              core.info(`Created issue #${created.data.number}`);
             }
-
-            const created = await github.rest.issues.create({
-              owner,
-              repo,
-              title,
-              body,
-              labels: ['dependencies', 'lambda'],
-            });
-
-            core.info(`Created issue #${created.data.number}`);

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -42,7 +42,12 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const issues = ${{ fromJSON(steps.check.outputs.issues) }};
+            const issuesRaw = ${{ toJSON(steps.check.outputs.issues) }};
+            const issues = JSON.parse(issuesRaw);
+
+            if (!Array.isArray(issues)) {
+              throw new TypeError(`issues is not an array: ${typeof issues}`);
+            }
             const { owner, repo } = context.repo;
 
             const existing = await github.rest.issues.listForRepo({

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -1,0 +1,72 @@
+name: Check Lambda Runtime Version Updates
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - cloudformation.yml
+      - .github/script/check_lambda_runtime_updates.py
+      - .github/workflows/check-lambda-runtime-version.yml
+  schedule:
+    # 06:00 Asia/Tokyo (GitHub Actions schedule uses UTC)
+    - cron: "0 21 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-lambda-runtime-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cfn-lint
+
+      - name: Check Lambda runtime updates from cfn-lint data
+        id: check
+        run: |
+          python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml
+
+      - name: Create issue when update exists
+        if: steps.check.outputs.has_update == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = ${{ toJSON(steps.check.outputs.issue_title) }};
+            const body = ${{ toJSON(steps.check.outputs.issue_body) }};
+
+            const { owner, repo } = context.repo;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              creator: 'github-actions[bot]',
+              per_page: 100,
+            });
+
+            const duplicate = existing.data.find((issue) => issue.title === title);
+            if (duplicate) {
+              core.info(`Issue already exists: #${duplicate.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['dependencies', 'lambda'],
+            });
+
+            core.info(`Created issue #${created.data.number}`);

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ aws cloudformation deploy \
 This repository runs `cfn-lint` on pull requests using `shogo82148/actions-cfn-lint@v1` (reviewdog integrated) and reports results as a PR check.
 Workflow file: `.github/workflows/reviewdog-cfn-lint.yml`.
 
-It also includes scheduled engine-version checks based on cfn-lint schema data:
-- RDS: `.github/workflows/check-rds-engine-version.yml`
-- ElastiCache: `.github/workflows/check-elasticache-engine-version.yml`
+It also includes scheduled engine/version checks based on cfn-lint schema data:
+- RDS engine: `.github/workflows/check-rds-engine-version.yml`
+- ElastiCache engine: `.github/workflows/check-elasticache-engine-version.yml`
+- Lambda runtime: `.github/workflows/check-lambda-runtime-version.yml`


### PR DESCRIPTION
### Motivation
- Provide a workflow analogous to the existing RDS/ElastiCache checks to detect out-of-date Lambda runtimes in the CloudFormation template.
- Use `cfn-lint` provider schema data to determine available Lambda runtimes and surface upgrade candidates automatically.

### Description
- Add ` .github/script/check_lambda_runtime_updates.py` which extracts `AWS::Lambda::Function` `Runtime` values and compares them against the provider schema via `ProviderSchemaManager` to find the latest runtime per family.
- Add `.github/workflows/check-lambda-runtime-version.yml` modeled after existing engine checks to run on `workflow_dispatch`/`pull_request`/`schedule` and create deduplicated issues with labels `dependencies` and `lambda` when updates exist.
- Update `README.md` to list the new Lambda runtime workflow alongside the RDS and ElastiCache checks.
- The checker prints JSON results and supports writing GitHub Actions outputs (`has_update`, `issue_title`, `issue_body`) via the `--github-output` option.

### Testing
- Ran `python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml` which completed successfully and reported updates for `NodeLambdaFunction` (`nodejs20.x -> nodejs24.x`) and `PythonLambdaFunction` (`python3.12 -> python3.14`).
- Ran `python .github/script/check_rds_engine_updates.py --template cloudformation.yml` which completed successfully and reported an RDS engine update for `MySQLDB`.
- Ran `python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml` which completed successfully and reported no ElastiCache updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b374d198832087045821efbbb07d)