### PR TITLE
Add AGENT.md and Japanese README; expand README with CI and workflow details

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,46 @@
+# AGENT.md
+
+このリポジトリは、CloudFormation テンプレート (`cloudformation.yml`) と、
+その継続的な品質/更新チェックを行う GitHub Actions で構成されています。
+
+## このリポジトリの目的
+- CloudFormation による検証用スタックの定義（RDS / ElastiCache / Lambda）。
+- `cfn-lint` によるテンプレート品質チェック。
+- `cfn-lint` が持つスキーマ情報を利用した、エンジン/ランタイム更新候補の自動検知。
+
+## 変更時の基本方針
+1. **最小変更**: 目的達成に必要な最小限の差分に留める。
+2. **説明可能性**: なぜ変更が必要かを README か PR 本文で説明する。
+3. **再現性**: ローカルで実行できる確認手順を残す。
+4. **安全性**: 本番利用を想定しない検証テンプレートである点を維持する。
+
+## CloudFormation (`cloudformation.yml`) を変更する場合
+- パラメータ互換性に注意する（既存パラメータ名の安易な変更を避ける）。
+- Engine/Runtime の値を更新した場合、対応する更新検知スクリプトの前提が壊れていないか確認する。
+- 可能であれば `cfn-lint cloudformation.yml` を実行する。
+- 破壊的変更（リソース種別変更、置換発生の可能性が高い変更）は README へ注意事項を追記する。
+
+## スクリプト (`.github/script/*.py`) を変更する場合
+- GitHub Actions 出力（`has_update`, `issue_title`, `issue_body`, `issues`）のキー互換性を保つ。
+- 文字列比較ではなくバージョン比較ロジック（`natural_version_key`）を利用する。
+- 可能であれば以下を実行して最低限の品質確認を行う。
+  - `python -m py_compile .github/script/check_rds_engine_updates.py`
+  - `python -m py_compile .github/script/check_elasticache_engine_updates.py`
+  - `python -m py_compile .github/script/check_lambda_runtime_updates.py`
+
+## GitHub Actions (`.github/workflows/*.yml`) を変更する場合
+- 既存のトリガー（`pull_request`, `schedule`, `workflow_dispatch`）の意図を維持する。
+- Issue 自動作成は重複防止ロジックを維持する。
+- Action のメジャーバージョン更新時は README の説明も合わせて更新する。
+
+## 推奨ローカル確認コマンド
+- `cfn-lint cloudformation.yml`
+- `python .github/script/check_rds_engine_updates.py --template cloudformation.yml`
+- `python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml`
+- `python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml`
+
+## ドキュメント運用
+- README を更新する際は `README.md`（英語）と `README.ja.md`（日本語）を必ず同時に更新し、内容の整合を保つ。
+- README は「初見の利用者が 5 分で概要と実行方法を理解できる」粒度を維持する。
+- 新しい運用ルールを追加したら、README または本ファイルへ反映する。
+

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,131 @@
+# poc-cfn-update-check
+
+CloudFormation テンプレート (`cloudformation.yml`) と、
+その品質/更新チェックを自動化する GitHub Actions をまとめた検証用リポジトリです。
+
+📘 English documentation: [README.md](README.md)
+
+## 何を作るテンプレートか
+
+`cloudformation.yml` では、以下のリソースを作成します。
+
+- Amazon RDS for MySQL (`AWS::RDS::DBInstance`)
+- Amazon ElastiCache Replication Group
+  - Redis
+  - Valkey
+- AWS Lambda 関数
+  - Node.js
+  - Python
+- それらで共通利用するリソース
+  - Security Group
+  - Subnet Group
+  - Lambda 実行ロール
+
+> [!NOTE]
+> このテンプレートは学習/検証用途のサンプルです。
+> そのまま本番利用する場合は、暗号化設定、可用性設計、認証情報管理、監査ログなどを別途強化してください。
+
+---
+
+## リポジトリ構成
+
+```text
+.
+├── cloudformation.yml
+├── AGENT.md
+├── README.md
+├── README.ja.md
+└── .github
+    ├── workflows
+    │   ├── reviewdog-cfn-lint.yml
+    │   ├── check-rds-engine-version.yml
+    │   ├── check-elasticache-engine-version.yml
+    │   └── check-lambda-runtime-version.yml
+    └── script
+        ├── check_rds_engine_updates.py
+        ├── check_elasticache_engine_updates.py
+        └── check_lambda_runtime_updates.py
+```
+
+---
+
+## デプロイ例
+
+事前に以下を準備してください。
+
+- AWS CLI 設定済みプロファイル
+- 対象 VPC
+- RDS / ElastiCache 用プライベートサブネット（2 つ以上）
+- Lambda を配置するサブネット
+
+```bash
+aws cloudformation deploy \
+  --template-file cloudformation.yml \
+  --stack-name poc-cfn-update-check \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    VpcId=vpc-xxxxxxxx \
+    PrivateSubnetIds='subnet-aaaaaaa,subnet-bbbbbbb' \
+    LambdaSubnetIds='subnet-aaaaaaa,subnet-bbbbbbb' \
+    DBPassword='YourStrongPassword123!'
+```
+
+---
+
+## CI/CD と自動チェック
+
+### 1) cfn-lint（PR 時の静的チェック）
+
+- Workflow: `.github/workflows/reviewdog-cfn-lint.yml`
+- Action: `shogo82148/actions-cfn-lint`
+- PR 上で cfn-lint 結果をチェックとして表示
+
+### 2) RDS EngineVersion 更新検知
+
+- Workflow: `.github/workflows/check-rds-engine-version.yml`
+- Script: `.github/script/check_rds_engine_updates.py`
+- `cfn-lint` が持つ RDS エンジンバージョン情報とテンプレートを比較し、更新候補があれば Issue 作成
+
+### 3) ElastiCache EngineVersion 更新検知
+
+- Workflow: `.github/workflows/check-elasticache-engine-version.yml`
+- Script: `.github/script/check_elasticache_engine_updates.py`
+- Redis / Valkey の EngineVersion 更新候補を検知して Issue 作成
+
+### 4) Lambda Runtime 更新検知
+
+- Workflow: `.github/workflows/check-lambda-runtime-version.yml`
+- Script: `.github/script/check_lambda_runtime_updates.py`
+- Runtime ファミリー単位（例: `nodejs*`, `python*`）で最新候補を判定し、更新候補ごとに Issue 作成
+
+### スケジュール実行
+
+3 つの更新検知 Workflow は日次スケジュールで実行されます（UTC cron: `0 21 * * *`）。
+これは **Asia/Tokyo 06:00** に相当します。
+
+---
+
+## ローカルでの確認方法
+
+```bash
+# 1) 依存をインストール
+python -m pip install --upgrade pip
+python -m pip install cfn-lint
+
+# 2) テンプレート lint
+cfn-lint cloudformation.yml
+
+# 3) 更新候補チェック
+python .github/script/check_rds_engine_updates.py --template cloudformation.yml
+python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml
+python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml
+```
+
+---
+
+## 変更時のガイド
+
+- CloudFormation を変更したら、`cfn-lint` と 3 つの更新チェックを実行して挙動を確認する。
+- Workflow を変更したら、README の該当説明も合わせて更新する。
+- `README.md`（英語）と `README.ja.md`（日本語）は必ず同期して更新する。
+- 運用ルールや作業ルールは `AGENT.md` を参照する。

--- a/README.md
+++ b/README.md
@@ -1,13 +1,61 @@
 # poc-cfn-update-check
 
-This repository includes `cloudformation.yml`, a sample AWS CloudFormation template.
+This repository is a proof-of-concept for a CloudFormation template (`cloudformation.yml`) and GitHub Actions that automate quality checks and version-update detection.
 
-The template provisions:
-- Amazon RDS for MySQL
-- Amazon ElastiCache for Redis (Replication Group)
-- AWS Lambda functions (Node.js and Python)
+📘 Japanese documentation: [README.ja.md](README.ja.md)
 
-## Example deployment
+## What this template provisions
+
+`cloudformation.yml` creates the following resources:
+
+- Amazon RDS for MySQL (`AWS::RDS::DBInstance`)
+- Amazon ElastiCache Replication Groups
+  - Redis
+  - Valkey
+- AWS Lambda functions
+  - Node.js
+  - Python
+- Shared networking and IAM resources
+  - Security Group
+  - Subnet Groups
+  - Lambda execution role
+
+> [!NOTE]
+> This is a sample template for learning and validation.
+> If you use it in production, harden security, availability, secret management, and observability settings.
+
+---
+
+## Repository layout
+
+```text
+.
+├── cloudformation.yml
+├── AGENT.md
+├── README.md
+├── README.ja.md
+└── .github
+    ├── workflows
+    │   ├── reviewdog-cfn-lint.yml
+    │   ├── check-rds-engine-version.yml
+    │   ├── check-elasticache-engine-version.yml
+    │   └── check-lambda-runtime-version.yml
+    └── script
+        ├── check_rds_engine_updates.py
+        ├── check_elasticache_engine_updates.py
+        └── check_lambda_runtime_updates.py
+```
+
+---
+
+## Deployment example
+
+Prerequisites:
+
+- AWS CLI configured
+- Target VPC
+- Two or more private subnets for RDS and ElastiCache
+- Subnets for Lambda VPC execution
 
 ```bash
 aws cloudformation deploy \
@@ -21,12 +69,62 @@ aws cloudformation deploy \
     DBPassword='YourStrongPassword123!'
 ```
 
-## CI (reviewdog + cfn-lint)
+---
 
-This repository runs `cfn-lint` on pull requests using `shogo82148/actions-cfn-lint@v1` (reviewdog integrated) and reports results as a PR check.
-Workflow file: `.github/workflows/reviewdog-cfn-lint.yml`.
+## CI and automated checks
 
-It also includes scheduled engine/version checks based on cfn-lint schema data:
-- RDS engine: `.github/workflows/check-rds-engine-version.yml`
-- ElastiCache engine: `.github/workflows/check-elasticache-engine-version.yml`
-- Lambda runtime: `.github/workflows/check-lambda-runtime-version.yml`
+### 1) cfn-lint on pull requests
+
+- Workflow: `.github/workflows/reviewdog-cfn-lint.yml`
+- Action: `shogo82148/actions-cfn-lint`
+- Reports template lint findings as PR checks
+
+### 2) RDS engine version update checks
+
+- Workflow: `.github/workflows/check-rds-engine-version.yml`
+- Script: `.github/script/check_rds_engine_updates.py`
+- Compares template `EngineVersion` values with cfn-lint schema data and opens an issue when newer versions are found
+
+### 3) ElastiCache engine version update checks
+
+- Workflow: `.github/workflows/check-elasticache-engine-version.yml`
+- Script: `.github/script/check_elasticache_engine_updates.py`
+- Detects Redis/Valkey `EngineVersion` updates and opens an issue when needed
+
+### 4) Lambda runtime update checks
+
+- Workflow: `.github/workflows/check-lambda-runtime-version.yml`
+- Script: `.github/script/check_lambda_runtime_updates.py`
+- Detects latest runtimes by family (for example `nodejs*`, `python*`) and opens issues for updatable resources
+
+### Scheduled runs
+
+The three update-check workflows run daily on UTC cron `0 21 * * *`.
+That corresponds to **06:00 Asia/Tokyo**.
+
+---
+
+## Local validation
+
+```bash
+# 1) Install dependencies
+python -m pip install --upgrade pip
+python -m pip install cfn-lint
+
+# 2) Lint template
+cfn-lint cloudformation.yml
+
+# 3) Check version/runtime updates
+python .github/script/check_rds_engine_updates.py --template cloudformation.yml
+python .github/script/check_elasticache_engine_updates.py --template cloudformation.yml
+python .github/script/check_lambda_runtime_updates.py --template cloudformation.yml
+```
+
+---
+
+## Contribution notes
+
+- Run `cfn-lint` and the three update-check scripts when changing the template.
+- Keep workflow behavior and documentation aligned when editing `.github/workflows/*`.
+- Keep `README.md` (English) and `README.ja.md` (Japanese) in sync.
+- See `AGENT.md` for detailed contributor/automation guidance.


### PR DESCRIPTION
### Motivation
- Provide contributor and automation guidance for maintaining the CloudFormation template and related scripts.
- Add Japanese documentation to make repository usage and CI flows accessible to Japanese readers.
- Clarify repository layout, CI workflows, and local validation steps for reproducible checks.

### Description
- Add `AGENT.md` with contribution rules, change policies, and local verification commands for scripts and templates.
- Add `README.ja.md` as a full Japanese translation describing the template, deployment example, CI workflows, and local checks.
- Expand `README.md` to document what the template provisions, list the repository layout, describe the three automated update-check workflows, and include local validation commands.
- Ensure references to `.github/workflows/*` and `.github/script/*` are documented and that `cfn-lint` and update-check scripts are mentioned for local testing.

### Testing
- No automated tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bb52a4788320b24b40d02e1f0862)