### PR TITLE
Update Valkey EngineVersion to 8.1 in CloudFormation template

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -174,7 +174,7 @@ Resources:
     Properties:
       ReplicationGroupDescription: Single-shard Valkey replication group
       Engine: valkey
-      EngineVersion: '7.2'
+      EngineVersion: '8.1'
       CacheNodeType: !Ref ValkeyNodeType
       NumNodeGroups: 1
       ReplicasPerNodeGroup: 1


### PR DESCRIPTION
### Motivation
- Update the ElastiCache Valkey engine version in the sample CloudFormation template to the requested newer version while keeping changes minimal.

### Description
- Changed `ValkeyReplicationGroup` `EngineVersion` in `cloudformation.yml` from `'7.2'` to `'8.1'` and made no other resource or parameter changes.

### Testing
- Attempted to run `cfn-lint cloudformation.yml`, but `cfn-lint` is not installed in the environment so linting could not be performed.
- No automated tests were run beyond the lint attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bf4510008320a35384107fc09962)