### PR TITLE
Update Lambda runtime to nodejs22.x in CloudFormation template

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -206,7 +206,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub '${AWS::StackName}-node-handler'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       MemorySize: !Ref LambdaMemorySize


### PR DESCRIPTION
### Motivation
- Bump the Lambda runtime for the sample Node.js function to `nodejs22.x` as requested while keeping the change minimal.

### Description
- Changed the `Runtime` of `NodeLambdaFunction` in `cloudformation.yml` from `nodejs20.x` to `nodejs22.x`.

### Testing
- Attempted to run `cfn-lint cloudformation.yml` but `cfn-lint` is not installed in the current environment, so linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bf6958d0832095f54713290b80b3)