### PR TITLE
Update Python Lambda runtime to python3.13 in CloudFormation template

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -238,7 +238,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub '${AWS::StackName}-python-handler'
-      Runtime: python3.12
+      Runtime: python3.13
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       MemorySize: !Ref LambdaMemorySize


### PR DESCRIPTION
### Motivation
- Align the sample CloudFormation template with the requested/latest Python Lambda runtime by updating the `PythonLambdaFunction` `Runtime` from `python3.12` to `python3.13`.

### Description
- Modified `cloudformation.yml` to set `PythonLambdaFunction` `Runtime` to `python3.13` (replacing `python3.12`).

### Testing
- Attempted to run `cfn-lint cloudformation.yml` but `cfn-lint` is not installed in the environment, so linting could not be performed; the file contents were inspected to confirm the runtime change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bf7938648320bd6a8e4a93bf811e)