### PR TITLE
refactor: share update-check script helpers

### DIFF
--- a/.github/script/check_elasticache_engine_updates.py
+++ b/.github/script/check_elasticache_engine_updates.py
@@ -6,20 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
 import cfnlint
-from cfnlint.decode import cfn_yaml
 
-
-def natural_version_key(value: str) -> list[Any]:
-    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
-    key: list[Any] = []
-    for p in parts:
-        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
-    return key
+from common import load_template_or_fail, natural_version_key, print_json_result, write_github_output
 
 
 def cfn_lint_elasticache_engine_versions(engine: str) -> list[str]:
@@ -113,12 +105,6 @@ def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str
     return title, "\n".join(lines)
 
 
-def write_github_output(path: str, outputs: dict[str, str]) -> None:
-    with open(path, "a", encoding="utf-8") as fp:
-        for key, value in outputs.items():
-            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
@@ -126,7 +112,7 @@ def main() -> int:
     args = parser.parse_args()
 
     template_path = Path(args.template)
-    template = cfn_yaml.load(str(template_path))
+    template = load_template_or_fail(template_path)
     elasticache_resources = extract_elasticache_resources(template)
 
     updates: list[dict[str, str]] = []
@@ -149,7 +135,7 @@ def main() -> int:
         "template": str(template_path),
         "updates": updates,
     }
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print_json_result(result)
 
     if args.github_output:
         write_github_output(

--- a/.github/script/check_lambda_runtime_updates.py
+++ b/.github/script/check_lambda_runtime_updates.py
@@ -6,20 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
-from cfnlint.decode import cfn_yaml
 from cfnlint.schema.manager import ProviderSchemaManager
 
-
-def natural_version_key(value: str) -> list[Any]:
-    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
-    key: list[Any] = []
-    for p in parts:
-        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
-    return key
+from common import load_template_or_fail, natural_version_key, print_json_result, write_github_output
 
 
 def runtime_family_and_version(runtime: str) -> tuple[str, str]:
@@ -92,12 +84,6 @@ def build_issue(update: dict[str, str], template_path: Path) -> tuple[str, str]:
     return title, "\n".join(lines)
 
 
-def write_github_output(path: str, outputs: dict[str, str]) -> None:
-    with open(path, "a", encoding="utf-8") as fp:
-        for key, value in outputs.items():
-            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
@@ -106,7 +92,7 @@ def main() -> int:
     args = parser.parse_args()
 
     template_path = Path(args.template)
-    template = cfn_yaml.load(str(template_path))
+    template = load_template_or_fail(template_path)
     lambda_resources = extract_lambda_resources(template)
     runtimes = cfn_lint_lambda_runtimes(args.region)
 
@@ -128,7 +114,7 @@ def main() -> int:
         "updates": updates,
         "issues": issue_payloads,
     }
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print_json_result(result)
 
     if args.github_output:
         write_github_output(

--- a/.github/script/check_rds_engine_updates.py
+++ b/.github/script/check_rds_engine_updates.py
@@ -6,20 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
 import cfnlint
-from cfnlint.decode import cfn_yaml
 
-
-def natural_version_key(value: str) -> list[Any]:
-    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
-    key: list[Any] = []
-    for p in parts:
-        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
-    return key
+from common import load_template_or_fail, natural_version_key, print_json_result, write_github_output
 
 
 def cfn_lint_rds_engine_versions(engine: str) -> list[str]:
@@ -88,12 +80,6 @@ def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str
     return title, "\n".join(lines)
 
 
-def write_github_output(path: str, outputs: dict[str, str]) -> None:
-    with open(path, "a", encoding="utf-8") as fp:
-        for key, value in outputs.items():
-            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
@@ -101,7 +87,7 @@ def main() -> int:
     args = parser.parse_args()
 
     template_path = Path(args.template)
-    template = cfn_yaml.load(str(template_path))
+    template = load_template_or_fail(template_path)
     rds_resources = extract_rds_resources(template)
 
     updates: list[dict[str, str]] = []
@@ -124,7 +110,7 @@ def main() -> int:
         "template": str(template_path),
         "updates": updates,
     }
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print_json_result(result)
 
     if args.github_output:
         write_github_output(

--- a/.github/script/common.py
+++ b/.github/script/common.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Common helpers for CloudFormation update check scripts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from cfnlint.decode import cfn_yaml
+
+
+def natural_version_key(value: str) -> list[Any]:
+    parts = re.findall(r"\d+|[A-Za-z]+", str(value))
+    key: list[Any] = []
+    for p in parts:
+        key.append((0, int(p)) if p.isdigit() else (1, p.lower()))
+    return key
+
+
+def write_github_output(path: str, outputs: dict[str, str]) -> None:
+    with open(path, "a", encoding="utf-8") as fp:
+        for key, value in outputs.items():
+            fp.write(f"{key}<<EOF\n{value}\nEOF\n")
+
+
+def print_json_result(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def load_template_or_fail(template_path: Path) -> dict[str, Any]:
+    template = cfn_yaml.load(str(template_path))
+    if not isinstance(template, dict):
+        raise ValueError(f"Template must be a JSON object at top level: {template_path}")
+    return template


### PR DESCRIPTION
### Motivation
- Reduce duplication between the CloudFormation update-check scripts by centralizing common utilities such as version keying, GitHub output formatting, template loading and JSON printing.

### Description
- Add `.github/script/common.py` with `natural_version_key`, `write_github_output`, `print_json_result`, and `load_template_or_fail` (which validates the template is a top-level object).
- Update `.github/script/check_rds_engine_updates.py` to import and use `load_template_or_fail`, `natural_version_key`, `print_json_result`, and `write_github_output` while preserving the existing CLI arguments and GitHub output keys.
- Update `.github/script/check_elasticache_engine_updates.py` to use the same common helpers and keep its CLI/output key behavior unchanged.
- Update `.github/script/check_lambda_runtime_updates.py` to use the common helpers and preserve `--region` and the existing GitHub output keys.

### Testing
- Run `python -m py_compile .github/script/common.py .github/script/check_rds_engine_updates.py .github/script/check_elasticache_engine_updates.py .github/script/check_lambda_runtime_updates.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14fcd6b088320a372f36f2299164c)