### PR TITLE
chore(scripts): add Japanese docstrings and comments to CloudFormation update check scripts

### DIFF
--- a/.github/script/check_elasticache_engine_updates.py
+++ b/.github/script/check_elasticache_engine_updates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check CloudFormation ElastiCache EngineVersion values against cfn-lint internal engine data."""
+"""CloudFormation の ElastiCache EngineVersion を cfn-lint の内部データと照合する。"""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from common import load_template_or_fail, natural_version_key, print_json_result
 
 
 def cfn_lint_elasticache_engine_versions(engine: str) -> list[str]:
+    """指定した ElastiCache エンジンで利用可能なバージョン一覧を cfn-lint データから読み込む。"""
     base = Path(cfnlint.__file__).resolve().parent
     candidate_paths = [
         base
@@ -23,8 +24,8 @@ def cfn_lint_elasticache_engine_versions(engine: str) -> list[str]:
         / "extensions"
         / "aws_elasticache_replicationgroup"
         / "engine_version.json",
-        # ReplicationGroup updates can be tracked with the same ElastiCache engine dataset
-        # when a dedicated schema extension file is not available.
+        # 専用の schema 拡張ファイルが無い場合は、同じ ElastiCache エンジン定義を使って
+        # ReplicationGroup の更新候補を追跡する。
         base
         / "data"
         / "schemas"
@@ -60,6 +61,7 @@ def cfn_lint_elasticache_engine_versions(engine: str) -> list[str]:
 
 
 def extract_elasticache_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    """ElastiCache ReplicationGroup の Logical ID・Engine・EngineVersion を抽出する。"""
     resources = template.get("Resources", {})
     results: list[dict[str, str]] = []
     for logical_id, resource in resources.items():
@@ -81,6 +83,7 @@ def extract_elasticache_resources(template: dict[str, Any]) -> list[dict[str, st
 
 
 def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
+    """1 件以上の ElastiCache エンジン更新候補を説明する Issue 情報を生成する。"""
     first = updates[0]
     title = (
         "chore: ElastiCache engine update available "
@@ -106,6 +109,7 @@ def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str
 
 
 def main() -> int:
+    """ElastiCache エンジン更新チェック CLI を実行し、構造化結果を出力する。"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
     parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))

--- a/.github/script/check_lambda_runtime_updates.py
+++ b/.github/script/check_lambda_runtime_updates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check CloudFormation Lambda Runtime values against cfn-lint provider schema data."""
+"""CloudFormation の Lambda Runtime を cfn-lint のスキーマデータと照合する。"""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from common import load_template_or_fail, natural_version_key, print_json_result
 
 
 def runtime_family_and_version(runtime: str) -> tuple[str, str]:
+    """Lambda runtime 文字列をファミリ接頭辞とバージョン接尾辞に分割する。"""
     if runtime.startswith("provided.al"):
         return "provided.al", runtime.removeprefix("provided.al")
 
@@ -27,6 +28,7 @@ def runtime_family_and_version(runtime: str) -> tuple[str, str]:
 
 
 def cfn_lint_lambda_runtimes(region: str = "us-east-1") -> list[str]:
+    """cfn-lint のプロバイダースキーマから並び替え可能な Runtime 一覧を取得する。"""
     manager = ProviderSchemaManager()
     schema = manager.get_resource_schema(region, "AWS::Lambda::Function")
     runtimes = schema.schema.get("properties", {}).get("Runtime", {}).get("enum", [])
@@ -34,6 +36,7 @@ def cfn_lint_lambda_runtimes(region: str = "us-east-1") -> list[str]:
 
 
 def latest_runtime_for_family(current_runtime: str, runtimes: list[str]) -> str | None:
+    """現在の runtime と同じファミリ内で最新の runtime を返す。"""
     family, _ = runtime_family_and_version(current_runtime)
 
     family_runtimes = [r for r in runtimes if runtime_family_and_version(r)[0] == family]
@@ -47,6 +50,7 @@ def latest_runtime_for_family(current_runtime: str, runtimes: list[str]) -> str 
 
 
 def extract_lambda_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    """テンプレートから Lambda の Logical ID と runtime 文字列を抽出する。"""
     resources = template.get("Resources", {})
     results: list[dict[str, str]] = []
     for logical_id, resource in resources.items():
@@ -66,6 +70,7 @@ def extract_lambda_resources(template: dict[str, Any]) -> list[dict[str, str]]:
 
 
 def build_issue(update: dict[str, str], template_path: Path) -> tuple[str, str]:
+    """検知した Lambda runtime 更新向けの Issue タイトルと本文を生成する。"""
     title = (
         "chore: Lambda runtime update available "
         f"({update['logical_id']} {update['current_runtime']} -> {update['latest_runtime']})"
@@ -85,6 +90,7 @@ def build_issue(update: dict[str, str], template_path: Path) -> tuple[str, str]:
 
 
 def main() -> int:
+    """Lambda runtime 更新チェック CLI を実行し、構造化結果を出力する。"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
     parser.add_argument("--region", default="us-east-1")

--- a/.github/script/check_rds_engine_updates.py
+++ b/.github/script/check_rds_engine_updates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check CloudFormation RDS EngineVersion values against cfn-lint internal engine data."""
+"""CloudFormation の RDS EngineVersion を cfn-lint の内部データと照合する。"""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from common import load_template_or_fail, natural_version_key, print_json_result
 
 
 def cfn_lint_rds_engine_versions(engine: str) -> list[str]:
+    """指定した RDS エンジンで利用可能なバージョン一覧を cfn-lint データから読み込む。"""
     base = Path(cfnlint.__file__).resolve().parent
     path = base / "data" / "schemas" / "extensions" / "aws_rds_dbinstance" / "engine_version.json"
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -38,6 +39,7 @@ def cfn_lint_rds_engine_versions(engine: str) -> list[str]:
 
 
 def extract_rds_resources(template: dict[str, Any]) -> list[dict[str, str]]:
+    """RDS DBInstance の Logical ID・Engine・EngineVersion を抽出する。"""
     resources = template.get("Resources", {})
     results: list[dict[str, str]] = []
     for logical_id, resource in resources.items():
@@ -59,6 +61,7 @@ def extract_rds_resources(template: dict[str, Any]) -> list[dict[str, str]]:
 
 
 def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str, str]:
+    """1 件以上の RDS エンジン更新候補を説明する Issue 情報を生成する。"""
     first = updates[0]
     title = (
         f"chore: RDS engine update available ({first['logical_id']} {first['current_version']} -> {first['latest_version']})"
@@ -81,6 +84,7 @@ def build_issue(updates: list[dict[str, str]], template_path: Path) -> tuple[str
 
 
 def main() -> int:
+    """RDS エンジン更新チェック CLI を実行し、構造化結果を出力する。"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--template", default="cloudformation.yml")
     parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))

--- a/.github/script/common.py
+++ b/.github/script/common.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Common helpers for CloudFormation update check scripts."""
+"""CloudFormation 更新チェック用スクリプトの共通ヘルパー。"""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from cfnlint.decode import cfn_yaml
 
 
 def natural_version_key(value: str) -> list[Any]:
+    """英数字が混在するバージョン文字列を自然順で比較するためのキーを返す。"""
     parts = re.findall(r"\d+|[A-Za-z]+", str(value))
     key: list[Any] = []
     for p in parts:
@@ -20,16 +21,19 @@ def natural_version_key(value: str) -> list[Any]:
 
 
 def write_github_output(path: str, outputs: dict[str, str]) -> None:
+    """GitHub Actions の出力ファイルに複数行の key/value を追記する。"""
     with open(path, "a", encoding="utf-8") as fp:
         for key, value in outputs.items():
             fp.write(f"{key}<<EOF\n{value}\nEOF\n")
 
 
 def print_json_result(payload: dict[str, Any]) -> None:
+    """ログ表示や後続処理向けに整形済み JSON を出力する。"""
     print(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 def load_template_or_fail(template_path: Path) -> dict[str, Any]:
+    """CloudFormation テンプレートを読み込み、トップレベルがマッピングか検証する。"""
     template = cfn_yaml.load(str(template_path))
     if not isinstance(template, dict):
         raise ValueError(f"Template must be a JSON object at top level: {template_path}")


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability by providing Japanese docstrings and comments for the CloudFormation update check scripts and shared helpers.

### Description
- Updated `check_elasticache_engine_updates.py`, `check_lambda_runtime_updates.py`, and `check_rds_engine_updates.py` to replace English module-level docstrings and add Japanese function docstrings and explanatory comments.
- Updated `common.py` with a Japanese module docstring and Japanese function docstrings for `natural_version_key`, `write_github_output`, `print_json_result`, and `load_template_or_fail`.
- These changes are documentation-only and do not modify runtime logic or output formatting.

### Testing
- Ran repository CI checks including linting and unit tests, and they completed successfully.
- Because no behavioral changes were introduced, existing automated tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f152134ea08320afe04a658370226d)