### PR TITLE
Pin GitHub Actions `uses:` entries to immutable commit SHAs

### DIFF
--- a/.github/workflows/check-elasticache-engine-version.yml
+++ b/.github/workflows/check-elasticache-engine-version.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issue when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const title = ${{ toJSON(steps.check.outputs.issue_title) }};

--- a/.github/workflows/check-elasticache-engine-version.yml
+++ b/.github/workflows/check-elasticache-engine-version.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issue when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = ${{ toJSON(steps.check.outputs.issue_title) }};

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issues when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issuesRaw = ${{ toJSON(steps.check.outputs.issues) }};

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issues when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issuesRaw = ${{ toJSON(steps.check.outputs.issues) }};

--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issue when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const title = ${{ toJSON(steps.check.outputs.issue_title) }};

--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create issue when update exists
         if: steps.check.outputs.has_update == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = ${{ toJSON(steps.check.outputs.issue_title) }};

--- a/.github/workflows/reviewdog-cfn-lint.yml
+++ b/.github/workflows/reviewdog-cfn-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Run cfn-lint with reviewdog
-        uses: shogo82148/actions-cfn-lint@bfb9458722f19d96c303a56ea984877174ce2b29 # v4
+        uses: shogo82148/actions-cfn-lint@bfb9458722f19d96c303a56ea984877174ce2b29 # v4.57.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/.github/workflows/reviewdog-cfn-lint.yml
+++ b/.github/workflows/reviewdog-cfn-lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0
 
       - name: Run cfn-lint with reviewdog
-        uses: shogo82148/actions-cfn-lint@v4
+        uses: shogo82148/actions-cfn-lint@bfb9458722f19d96c303a56ea984877174ce2b29 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check


### PR DESCRIPTION
### Motivation
- Reduce supply-chain risk by replacing mutable tag references in workflow `uses:` entries with immutable commit SHAs. 
- Ensure deterministic resolution of action versions across runs by pinning to specific commit SHAs. 
- Apply the requested explicit pin for `actions/checkout` (`actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0`).

### Description
- Replaced `actions/checkout@v6` with `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.0` in four workflow files. 
- Pinned other actions to their resolved SHAs: `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6`, `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9`, and `shogo82148/actions-cfn-lint@bfb9458722f19d96c303a56ea984877174ce2b29 # v4`. 
- Modified files: `.github/workflows/check-elasticache-engine-version.yml`, `.github/workflows/check-lambda-runtime-version.yml`, `.github/workflows/check-rds-engine-version.yml`, and `.github/workflows/reviewdog-cfn-lint.yml`.

### Testing
- Ran `rg -n "uses:\s*" .github/workflows` to locate `uses:` entries and verify replacements, which succeeded. 
- Resolved tag names to commit SHAs via a small `python` script calling the GitHub API to determine immutable SHAs, which succeeded. 
- Verified the produced diffs with `git diff -- .github/workflows` and inspected the updated workflows with `nl -ba`, which confirmed the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb6bb89cc8320999ae1f67388fc1a)