### PR TITLE
chore: update actions/checkout comment to v6.0.2

### DIFF
--- a/.github/workflows/check-elasticache-engine-version.yml
+++ b/.github/workflows/check-elasticache-engine-version.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/check-lambda-runtime-version.yml
+++ b/.github/workflows/check-lambda-runtime-version.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/check-rds-engine-version.yml
+++ b/.github/workflows/check-rds-engine-version.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/reviewdog-cfn-lint.yml
+++ b/.github/workflows/reviewdog-cfn-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run cfn-lint with reviewdog
         uses: shogo82148/actions-cfn-lint@bfb9458722f19d96c303a56ea984877174ce2b29 # v4.57.0


### PR DESCRIPTION
### Motivation
- Align the documented minor version in workflow comments for `actions/checkout` from `# v6.0.0` to `# v6.0.2` so annotations reflect the intended version.

### Description
- Replaced `# v6.0.0` with `# v6.0.2` for `actions/checkout` in four workflow files under `.github/workflows`.
- Files modified: `.github/workflows/check-elasticache-engine-version.yml`, `.github/workflows/check-lambda-runtime-version.yml`, `.github/workflows/check-rds-engine-version.yml`, and `.github/workflows/reviewdog-cfn-lint.yml`.
- The pinned action SHA (`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`) was not changed, making this a metadata/comment-only update.

### Testing
- Ran `rg -n "actions/checkout|v6\.0\.0|v6\.0\.2" .github` to confirm occurrences were updated, which succeeded.
- Verified the textual diffs with `git diff -- .github/workflows/*.yml` to review the changes, which succeeded.
- Printed file regions with `nl -ba ... | sed -n` to confirm the new `# v6.0.2` annotations appear in each workflow, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec98741f88320b2841d3d6a7a645c)